### PR TITLE
Further Teardown Improvements

### DIFF
--- a/src/cdpy/common.py
+++ b/src/cdpy/common.py
@@ -361,9 +361,10 @@ class CdpcliWrapper(object):
             describe_func (func): The status check function to call as it relates to the sdk object,
                 e.g self.cdpy.opdb.describe_database
             params (dict): Parameters the describe_func requires to poll the status, e.g. { name=myname, env=myenv }
-            field (str, None): The field to check in the describe_func output for the state. Use None to check for
+            field (str, None, list): The field to check in the describe_func output for the state. Use None to check for
                 listing removal during deletion. Provide a list of strings for nested structures. Defaults to 'status'
-            state (list, str, None): The state or list of states valid for return from wait function. Defaults to None
+            state (list, str, None): The state or list of states valid for return from wait function, list of states
+                may include None for object removal. Defaults to None.
             delay (int): Delay in seconds between each poll of the describe_func. Default is 15
             timeout (int): Total wait time in seconds before the function should return a timeout. Default is 3600
             ignore_failures (bool): Whether to ignore failed states when waiting for a forced deletion
@@ -379,7 +380,7 @@ class CdpcliWrapper(object):
         while time() < start_time + timeout:
             current = describe_func(**params)
             if current is None:
-                if field is None:
+                if field is None or None in state:
                     return current
                 else:
                     self.logger.info("Waiting for identity {0} to be returned by function {1}")

--- a/src/cdpy/df.py
+++ b/src/cdpy/df.py
@@ -7,7 +7,7 @@ class CdpyDf(CdpSdkBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def list_environments(self, only_enabled=False):
+    def list_environments(self, only_enabled=False, name=None):
         result = self.sdk.call(
             svc='df', func='list_environments', ret_field='environments', squelch=[
                 Squelch(value='NOT_FOUND', default=list(),
@@ -16,10 +16,12 @@ class CdpyDf(CdpSdkBase):
             pageSize=self.sdk.DEFAULT_PAGE_SIZE
         )
         if only_enabled:
-            return [x for x in result if x['status']['state'] not in ['NOT_ENABLED']]
+            result = [x for x in result if x['status']['state'] not in ['NOT_ENABLED']]
+        if name is not None:
+            result = [x for x in result if x['name'] == name]
         return result
 
-    def describe_environment(self, env_crn: str):
+    def describe_environment(self, env_crn: str = None):
         return self.sdk.call(
             svc='df', func='get_environment', ret_field='environment', squelch=[
                 Squelch(value='NOT_FOUND',
@@ -37,19 +39,16 @@ class CdpyDf(CdpSdkBase):
             usePublicLoadBalancer=enable_public_ip, authorizedIpRanges=authorized_ips
         )
 
-    def disable_environment(self, env_crn: str, persist: bool = False, force: bool = False):
+    def disable_environment(self, env_crn: str, persist: bool = False):
         self.sdk.validate_crn(env_crn)
-        resp = self.sdk.call(
+        return self.sdk.call(
             svc='df', func='disable_environment', ret_field='status', ret_error=True,
             crn=env_crn, persist=persist
         )
-        if isinstance(resp, CdpError):
-            if force:
-                return self.sdk.call(
-                    svc='df', func='delete_environment',
-                    crn=env_crn
-                )
-            else:
-                resp.update(message=resp.violations)
-                self.sdk.throw_error(resp)
-        return resp
+
+    def delete_environment(self, env_crn: str):
+        self.sdk.validate_crn(env_crn)
+        return self.sdk.call(
+            svc='df', func='delete_environment',
+            crn=env_crn
+        )


### PR DESCRIPTION
Add option to filter DF listings by a name as describe environment will return None if DF Service is disabled but not removed, whereas it still appears in listings
Split DF disable and DF delete functions to provide better clarity in usage.
Improve wait_for_state to allow None to be included in the list of valid finish states - this allows the user to specify they are waiting for a failure state or removal during teardown

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>