### PR TITLE
Handle StaticCredentials

### DIFF
--- a/src/cdpy/common.py
+++ b/src/cdpy/common.py
@@ -19,7 +19,6 @@ from typing import Union
 import urllib.parse as urlparse
 from os import path
 
-import cdpcli
 from cdpcli import VERSION as CDPCLI_VERSION
 from cdpcli.client import ClientCreator, Context
 from cdpcli.credentials import Credentials

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,11 @@
+from cdpy.common import StaticCredentials
+from cdpy.cdpy import Cdpy
+
+def test_static_credentials():
+    ACCESS_KEY_ID = "thekey"
+    PRIVATE_KEY = "theanswer"
+    
+    iam = Cdpy(cdp_credentials=StaticCredentials(ACCESS_KEY_ID, PRIVATE_KEY)).iam
+    
+    assert iam.sdk.cdp_credentials.access_key_id == ACCESS_KEY_ID
+    assert iam.sdk.cdp_credentials.private_key == PRIVATE_KEY

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,5 +1,6 @@
 from cdpy.common import StaticCredentials
 from cdpy.cdpy import Cdpy
+from cdpy.iam import CdpyIam
 
 def test_static_credentials():
     ACCESS_KEY_ID = "thekey"
@@ -9,3 +10,13 @@ def test_static_credentials():
     
     assert iam.sdk.cdp_credentials.access_key_id == ACCESS_KEY_ID
     assert iam.sdk.cdp_credentials.private_key == PRIVATE_KEY
+
+def test_static_credentials_submodule():
+    ACCESS_KEY_ID = "thekey"
+    PRIVATE_KEY = "theanswer"
+    
+    iam = CdpyIam(cdp_credentials=StaticCredentials(ACCESS_KEY_ID, PRIVATE_KEY))
+    
+    assert iam.sdk.cdp_credentials.access_key_id == ACCESS_KEY_ID
+    assert iam.sdk.cdp_credentials.private_key == PRIVATE_KEY
+    


### PR DESCRIPTION
Handle Cdpy() and submodule use of StaticCredentials, i.e. direct credential assignment.