### PR TITLE
Change recommended VCS download command to https

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Installation
 
 To install directly from latest commits, in python requirements.txt ::
 
-    git+git://github.com/cloudera-labs/cdpy@main#egg=cdpy
+    git+https://github.com/cloudera-labs/cdpy@main#egg=cdpy
 
 For General usage, installed from cmdline ::
 
@@ -18,7 +18,7 @@ For General usage, installed from cmdline ::
 
 To install the development branch instead of main ::
 
-    git+git://github.com/cloudera-labs/cdpy@devel#egg=cdpy
+    git+https://github.com/cloudera-labs/cdpy@devel#egg=cdpy
 
 Usage
 =====


### PR DESCRIPTION
As per [pip documentation on VCS support](https://pip.pypa.io/en/stable/topics/vcs-support/#supported-vcs), it is recommended to use a TLS approach when installing Python packages from Git repositories. Have updated the readme for this.

Fixes #60.