### PR TITLE
Add noProxyHosts parameter to create_proxy_config

### DIFF
--- a/src/cdpy/environments.py
+++ b/src/cdpy/environments.py
@@ -16,11 +16,12 @@ class CdpyEnvironments(CdpSdkBase):
         return self.sdk.first_item_if_exists(resp)
 
     def create_proxy_config(self, name, host=None, port=None, protocol=None, description=None,
-                            user=None, password=None):
+                            noProxyHosts=None, user=None, password=None):
+
         return self.sdk.call(
             svc='environments', func='create_proxy_config', ret_field='proxyConfig',
             proxyConfigName=name, host=host, port=port,
-            protocol=protocol, description=description, user=user, password=password
+            protocol=protocol, description=description, noProxyHosts=noProxyHosts, user=user, password=password
         )
 
     def delete_proxy_config(self, name):

--- a/src/cdpy/environments.py
+++ b/src/cdpy/environments.py
@@ -15,12 +15,12 @@ class CdpyEnvironments(CdpSdkBase):
         resp = self.list_proxy_configs(name)
         return self.sdk.first_item_if_exists(resp)
 
-    def create_proxy_config(self, name, host=None, port=None, protocol=None, description=None,
+    def create_proxy_config(self, proxyConfigName, host=None, port=None, protocol=None, description=None,
                             noProxyHosts=None, user=None, password=None):
 
         return self.sdk.call(
             svc='environments', func='create_proxy_config', ret_field='proxyConfig',
-            proxyConfigName=name, host=host, port=port,
+            proxyConfigName=proxyConfigName, host=host, port=port,
             protocol=protocol, description=description, noProxyHosts=noProxyHosts, user=user, password=password
         )
 


### PR DESCRIPTION
Also renamed `name` input parameter to be `proxyConfigName` in the create_proxy_config method. This allows for an idempotency check in cloudera.cloud.env_proxy.